### PR TITLE
Ts 43 reopen past goals

### DIFF
--- a/fundstrackerproject/fundstrackerapp/templates/pastgoals/form.html
+++ b/fundstrackerproject/fundstrackerapp/templates/pastgoals/form.html
@@ -1,0 +1,42 @@
+{% extends 'shared/base.html' %}
+{% load static %}
+
+{% block css %}
+    <link rel="stylesheet" href="{% static 'styles/pastgoaleditform.css' %}" />
+{% endblock %}
+
+
+{% block content %}
+
+{% if financial_goal.id is not None %}
+    <form action="{% url 'fundstrackerapp:past_goal_details' financial_goal.id %}" method="post">
+        <input type="hidden" name="actual_method" value="PUT">
+{% endif %}
+      {% csrf_token %}
+      <fieldset>
+          <label for="name">Goal Name:</label>
+          <input id="name" type="text" name="name" value="{{ financial_goal.goal }}" />
+      </fieldset>
+      <fieldset>
+          <label for="time_horizon">Time Horizon:</label>
+          <select id="time_horizon" name="time_horizon" required>
+            <option hidden disabled selected value> -- select an option -- </option>
+            <option {% if financial_goal.timeframe == 1 %}selected="selected"{% endif %} value="1">1 Month</option>
+            <option {% if financial_goal.timeframe == 3 %}selected="selected"{% endif %} value="3">3 Months</option>
+            <option {% if financial_goal.timeframe == 6 %}selected="selected"{% endif %} value="6">6 Months</option>
+            <option {% if financial_goal.timeframe == 12 %}selected="selected"{% endif %} value="12">1 Year</option>
+          </select>
+      </fieldset>
+      
+       <input type="submit" value="Submit" />
+    </form>
+    
+    {% if financial_goal.id is not None %}
+    <form action="{% url 'fundstrackerapp:past_goal_details' financial_goal.id %}" method="POST">
+        {% csrf_token %}
+        <input type="hidden" name="actual_method" value="DELETE" />
+        <button onclick="return confirm('Are you sure?');">Delete</button>
+    </form>
+    {% endif %}
+
+{% endblock %}

--- a/fundstrackerproject/fundstrackerapp/templates/pastgoals/list.html
+++ b/fundstrackerproject/fundstrackerapp/templates/pastgoals/list.html
@@ -15,7 +15,7 @@
                 {% for goal in past_one_month_goals %}
                 <li>{{ goal.goal }} {% if goal.is_completed %}<span>Completed</span>{% endif %} </li>
                 <span>Created: {{ goal.created_at }}</span>
-                {% if goal.is_completed != 1%}<button>Re-open Goal</button>{% endif %}
+                {% if goal.is_completed != 1%}<a href="{% url 'fundstrackerapp:past_goal_edit_form' goal.id %}"><button>Re-open Goal</button></a>{% endif %}
                 {% endfor %}
             </ul>
         </section>
@@ -26,7 +26,7 @@
                 {% for goal in past_three_month_goals %}
                 <li>{{ goal.goal }} {% if goal.is_completed %}<span>Completed</span>{% endif %} </li>
                 <span>Created: {{ goal.created_at }}</span>
-                {% if goal.is_completed != 1%}<button>Re-open Goal</button>{% endif %}
+                {% if goal.is_completed != 1%}<a href="{% url 'fundstrackerapp:past_goal_edit_form' goal.id %}"><button>Re-open Goal</button></a>{% endif %}
                 {% endfor %}
             </ul>
         </section>
@@ -37,7 +37,7 @@
                 {% for goal in past_six_month_goals %}
                 <li>{{ goal.goal }} {% if goal.is_completed %}<span>Completed</span>{% endif %} </li>
                 <span>Created: {{ goal.created_at }}</span>
-                {% if goal.is_completed != 1%}<button>Re-open Goal</button>{% endif %}
+                {% if goal.is_completed != 1%}<a href="{% url 'fundstrackerapp:past_goal_edit_form' goal.id %}"><button>Re-open Goal</button></a>{% endif %}
                 {% endfor %}
             </ul>
         </section>
@@ -48,7 +48,7 @@
                 {% for goal in past_twelve_month_goals %}
                 <li>{{ goal.goal }} {% if goal.is_completed %}<span>Completed</span>{% endif %} </li>
                 <span>Created: {{ goal.created_at }}</span>
-                {% if goal.is_completed != 1%}<button>Re-open Goal</button>{% endif %}
+                {% if goal.is_completed != 1%}<a href="{% url 'fundstrackerapp:past_goal_edit_form' goal.id %}"><button>Re-open Goal</button></a>{% endif %}
                 {% endfor %}
             </ul>
         </section>

--- a/fundstrackerproject/fundstrackerapp/templates/pastgoals/list.html
+++ b/fundstrackerproject/fundstrackerapp/templates/pastgoals/list.html
@@ -15,6 +15,7 @@
                 {% for goal in past_one_month_goals %}
                 <li>{{ goal.goal }} {% if goal.is_completed %}<span>Completed</span>{% endif %} </li>
                 <span>Created: {{ goal.created_at }}</span>
+                {% if goal.is_completed != 1%}<button>Re-open Goal</button>{% endif %}
                 {% endfor %}
             </ul>
         </section>
@@ -25,6 +26,7 @@
                 {% for goal in past_three_month_goals %}
                 <li>{{ goal.goal }} {% if goal.is_completed %}<span>Completed</span>{% endif %} </li>
                 <span>Created: {{ goal.created_at }}</span>
+                {% if goal.is_completed != 1%}<button>Re-open Goal</button>{% endif %}
                 {% endfor %}
             </ul>
         </section>
@@ -35,6 +37,7 @@
                 {% for goal in past_six_month_goals %}
                 <li>{{ goal.goal }} {% if goal.is_completed %}<span>Completed</span>{% endif %} </li>
                 <span>Created: {{ goal.created_at }}</span>
+                {% if goal.is_completed != 1%}<button>Re-open Goal</button>{% endif %}
                 {% endfor %}
             </ul>
         </section>
@@ -45,6 +48,7 @@
                 {% for goal in past_twelve_month_goals %}
                 <li>{{ goal.goal }} {% if goal.is_completed %}<span>Completed</span>{% endif %} </li>
                 <span>Created: {{ goal.created_at }}</span>
+                {% if goal.is_completed != 1%}<button>Re-open Goal</button>{% endif %}
                 {% endfor %}
             </ul>
         </section>

--- a/fundstrackerproject/fundstrackerapp/urls.py
+++ b/fundstrackerproject/fundstrackerapp/urls.py
@@ -24,5 +24,7 @@ urlpatterns = [
     path('goals/<int:goal_id>/complete', goal_completed, name='goal_completed'),
     path('goals/completed', goal_completed_list, name='goal_completed_list'),
     path('pastgoals/', past_goals_list, name='past_goals_list'),
+    path('pastgoals/<int:goal_id>/form', past_goal_edit_form, name='past_goal_edit_form'),
+    path('pastgoals/<int:goal_id>/', past_goal_details, name='past_goal_details'),
 
 ]

--- a/fundstrackerproject/fundstrackerapp/views/__init__.py
+++ b/fundstrackerproject/fundstrackerapp/views/__init__.py
@@ -14,3 +14,5 @@ from .goals.details import goal_details
 from .goals.completed import goal_completed
 from .goals.completedlist import goal_completed_list
 from .pastgoals.list import past_goals_list
+from .pastgoals.details import past_goal_details
+from .pastgoals.form import past_goal_edit_form

--- a/fundstrackerproject/fundstrackerapp/views/goals/details.py
+++ b/fundstrackerproject/fundstrackerapp/views/goals/details.py
@@ -28,6 +28,7 @@ def goal_details(request, goal_id):
         ):
             goal.goal = form_data['name']
             goal.timeframe = form_data['time_horizon']
+            goal.is_completed = 0
             goal.save()
 
             return redirect(reverse('fundstrackerapp:goals'))

--- a/fundstrackerproject/fundstrackerapp/views/goals/details.py
+++ b/fundstrackerproject/fundstrackerapp/views/goals/details.py
@@ -28,7 +28,6 @@ def goal_details(request, goal_id):
         ):
             goal.goal = form_data['name']
             goal.timeframe = form_data['time_horizon']
-            goal.is_completed = 0
             goal.save()
 
             return redirect(reverse('fundstrackerapp:goals'))

--- a/fundstrackerproject/fundstrackerapp/views/pastgoals/details.py
+++ b/fundstrackerproject/fundstrackerapp/views/pastgoals/details.py
@@ -1,0 +1,38 @@
+from django.urls import reverse
+from django.shortcuts import render, redirect
+from django.contrib.auth.decorators import login_required
+from fundstrackerapp.models import FinancialGoal
+from datetime import datetime
+
+def get_financial_goal(goal_id):
+    return FinancialGoal.objects.get(pk=goal_id)
+
+@login_required
+def past_goal_details(request, goal_id):
+    
+    goal = get_financial_goal(goal_id)
+
+    if request.method == 'POST':
+        form_data = request.POST
+
+        if (
+            "actual_method" in form_data
+            and form_data["actual_method"] == "DELETE"
+        ):
+            goal.delete()
+
+            return redirect(reverse('fundstrackerapp:goals'))
+            
+        if (
+            "actual_method" in form_data
+            and form_data["actual_method"] == "PUT"
+        ):
+            goal.goal = form_data['name']
+            goal.created_at = datetime.now()
+            goal.timeframe = form_data['time_horizon']
+            goal.is_completed = 0
+            goal.save()
+
+            return redirect(reverse('fundstrackerapp:goals'))
+
+            

--- a/fundstrackerproject/fundstrackerapp/views/pastgoals/form.py
+++ b/fundstrackerproject/fundstrackerapp/views/pastgoals/form.py
@@ -1,0 +1,17 @@
+from django.shortcuts import render, redirect, reverse
+from fundstrackerapp.models import FinancialGoal
+from django.contrib.auth.models import User
+from django.contrib.auth.decorators import login_required
+
+@login_required
+def past_goal_edit_form(request, goal_id):
+
+    if request.method == 'GET':
+        financial_goal = FinancialGoal.objects.get(pk=goal_id)
+
+        template = 'pastgoals/form.html'
+        context = {
+            'financial_goal': financial_goal
+        }
+
+        return render(request, template, context)


### PR DESCRIPTION
_Changes made_

1. Added past_goal_edit_form and past_goal_details views to handle the editing of a past goal with a new update to the created_at field with the current datetime to move the past goal into current goals list again
2. Added both new views as URL patterns
3. Added 'Re-open Goal' button to each past goal in past goals list.html template to render past_goal_edit_form view
4. Added form.html template for past goals to edit a past goal and resubmit it as a new current goal